### PR TITLE
Implement basic services and configuration

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          cd backend
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Lint
+        run: |
+          cd backend
+          flake8 app tests
+      - name: Test
+        run: |
+          cd backend
+          pytest

--- a/README.md
+++ b/README.md
@@ -4,13 +4,22 @@ This repository contains a skeleton implementation of the Risk Analytics Dashboa
 
 ## Backend
 
-The backend is built with **FastAPI**. To run the API locally:
+The backend is built with **FastAPI** and uses Pydantic settings for
+configuration. Copy `.env.example` to `.env` and adjust if needed. To run
+the API locally:
 
 ```bash
 cd backend
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 uvicorn app.main:app --reload
+```
+
+Run the test suite with:
+
+```bash
+cd backend
+pytest
 ```
 
 The API exposes simple endpoints under `/risk`, `/metrics`, and `/alerts`.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+ENVIRONMENT=development
+APP_NAME=Risk Analytics Dashboard API

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,3 @@
+from .config import settings
+
+__all__ = ["settings"]

--- a/backend/app/config/__init__.py
+++ b/backend/app/config/__init__.py
@@ -1,0 +1,3 @@
+from .settings import Settings
+
+settings = Settings()

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -1,4 +1,4 @@
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -1,0 +1,8 @@
+from pydantic import BaseSettings
+
+class Settings(BaseSettings):
+    app_name: str = "Risk Analytics Dashboard API"
+    environment: str = "development"
+
+    class Config:
+        env_file = ".env"

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -1,5 +1,6 @@
 from pydantic import BaseSettings
 
+
 class Settings(BaseSettings):
     app_name: str = "Risk Analytics Dashboard API"
     environment: str = "development"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI, WebSocket
 from .routers import risk, metrics, alert
 from .config import settings
 
+
 app = FastAPI(title=settings.app_name)
 
 app.include_router(risk.router, prefix="/risk", tags=["risk"])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,9 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, WebSocket
 
 from .routers import risk, metrics, alert
+from .config import settings
 
-app = FastAPI(title="Risk Analytics Dashboard API")
+app = FastAPI(title=settings.app_name)
 
 app.include_router(risk.router, prefix="/risk", tags=["risk"])
 app.include_router(metrics.router, prefix="/metrics", tags=["metrics"])
@@ -10,5 +11,12 @@ app.include_router(alert.router, prefix="/alerts", tags=["alerts"])
 
 @app.get("/")
 def read_root():
-    return {"message": "Risk Analytics Dashboard API"}
+    return {"message": settings.app_name, "environment": settings.environment}
+
+
+@app.websocket("/ws/risk")
+async def risk_stream(websocket: WebSocket):
+    await websocket.accept()
+    await websocket.send_text("risk_stream_connected")
+    await websocket.close()
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ app.include_router(risk.router, prefix="/risk", tags=["risk"])
 app.include_router(metrics.router, prefix="/metrics", tags=["metrics"])
 app.include_router(alert.router, prefix="/alerts", tags=["alerts"])
 
+
 @app.get("/")
 def read_root():
     return {"message": settings.app_name, "environment": settings.environment}
@@ -19,4 +20,3 @@ async def risk_stream(websocket: WebSocket):
     await websocket.accept()
     await websocket.send_text("risk_stream_connected")
     await websocket.close()
-

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -4,11 +4,13 @@ from uuid import UUID
 from datetime import datetime, timedelta
 from pydantic import BaseModel
 
+
 class Thresholds(BaseModel):
     low: float
     medium: float
     high: float
     critical: float
+
 
 class RiskIndicator(BaseModel):
     id: UUID
@@ -22,6 +24,7 @@ class RiskIndicator(BaseModel):
     update_frequency: timedelta
     owner: str
 
+
 class RiskLevel(str, Enum):
     low = "low"
     medium = "medium"
@@ -29,10 +32,12 @@ class RiskLevel(str, Enum):
     critical = "critical"
 
 
+
 class AlertSeverity(str, Enum):
     info = "info"
     warning = "warning"
     critical = "critical"
+
 
 
 class RiskSnapshot(BaseModel):
@@ -43,6 +48,7 @@ class RiskSnapshot(BaseModel):
     risk_level: RiskLevel
     trend: str
     confidence: float
+
 
 class Alert(BaseModel):
     id: UUID

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -32,12 +32,10 @@ class RiskLevel(str, Enum):
     critical = "critical"
 
 
-
 class AlertSeverity(str, Enum):
     info = "info"
     warning = "warning"
     critical = "critical"
-
 
 
 class RiskSnapshot(BaseModel):

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,4 +1,5 @@
 from typing import List, Optional
+from enum import Enum
 from uuid import UUID
 from datetime import datetime, timedelta
 from pydantic import BaseModel
@@ -21,12 +22,25 @@ class RiskIndicator(BaseModel):
     update_frequency: timedelta
     owner: str
 
+class RiskLevel(str, Enum):
+    low = "low"
+    medium = "medium"
+    high = "high"
+    critical = "critical"
+
+
+class AlertSeverity(str, Enum):
+    info = "info"
+    warning = "warning"
+    critical = "critical"
+
+
 class RiskSnapshot(BaseModel):
     timestamp: datetime
     indicator_id: UUID
     value: float
     normalized_score: float
-    risk_level: str
+    risk_level: RiskLevel
     trend: str
     confidence: float
 
@@ -34,7 +48,7 @@ class Alert(BaseModel):
     id: UUID
     indicator_id: UUID
     triggered_at: datetime
-    severity: str
+    severity: AlertSeverity
     title: str
     description: str
     recommended_actions: List[str]

--- a/backend/app/routers/alert.py
+++ b/backend/app/routers/alert.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 from ..services import list_alerts as list_alerts_service
 
+
 router = APIRouter()
 
 

--- a/backend/app/routers/alert.py
+++ b/backend/app/routers/alert.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter
+from ..services import list_alerts as list_alerts_service
 
 router = APIRouter()
 
 @router.get("/")
 def list_alerts():
-    return []
+    return list_alerts_service()
 

--- a/backend/app/routers/alert.py
+++ b/backend/app/routers/alert.py
@@ -3,7 +3,7 @@ from ..services import list_alerts as list_alerts_service
 
 router = APIRouter()
 
+
 @router.get("/")
 def list_alerts():
     return list_alerts_service()
-

--- a/backend/app/routers/metrics.py
+++ b/backend/app/routers/metrics.py
@@ -3,7 +3,7 @@ from ..services import overview as metrics_overview_service
 
 router = APIRouter()
 
+
 @router.get("/overview")
 def metrics_overview():
     return metrics_overview_service()
-

--- a/backend/app/routers/metrics.py
+++ b/backend/app/routers/metrics.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter
+from ..services import overview as metrics_overview_service
 
 router = APIRouter()
 
 @router.get("/overview")
 def metrics_overview():
-    return {}
+    return metrics_overview_service()
 

--- a/backend/app/routers/metrics.py
+++ b/backend/app/routers/metrics.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 from ..services import overview as metrics_overview_service
 
+
 router = APIRouter()
 
 

--- a/backend/app/routers/risk.py
+++ b/backend/app/routers/risk.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter
+from ..services import list_indicators as list_indicators_service
 
 router = APIRouter()
 
 @router.get("/indicators")
 def list_indicators():
-    return []
+    return list_indicators_service()
 

--- a/backend/app/routers/risk.py
+++ b/backend/app/routers/risk.py
@@ -3,7 +3,7 @@ from ..services import list_indicators as list_indicators_service
 
 router = APIRouter()
 
+
 @router.get("/indicators")
 def list_indicators():
     return list_indicators_service()
-

--- a/backend/app/routers/risk.py
+++ b/backend/app/routers/risk.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 from ..services import list_indicators as list_indicators_service
 
+
 router = APIRouter()
 
 

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,10 @@
+from .risk_service import list_indicators, add_indicator
+from .alert_service import list_alerts
+from .metrics_service import overview
+
+__all__ = [
+    'list_indicators',
+    'add_indicator',
+    'list_alerts',
+    'overview'
+]

--- a/backend/app/services/alert_service.py
+++ b/backend/app/services/alert_service.py
@@ -1,0 +1,8 @@
+from typing import List
+from ..models import Alert
+
+_fake_alerts: List[Alert] = []
+
+
+def list_alerts() -> List[Alert]:
+    return _fake_alerts

--- a/backend/app/services/alert_service.py
+++ b/backend/app/services/alert_service.py
@@ -1,6 +1,7 @@
 from typing import List
 from ..models import Alert
 
+
 _fake_alerts: List[Alert] = []
 
 

--- a/backend/app/services/metrics_service.py
+++ b/backend/app/services/metrics_service.py
@@ -1,0 +1,5 @@
+from typing import Dict
+
+
+def overview() -> Dict[str, int]:
+    return {"indicators": 0, "alerts": 0}

--- a/backend/app/services/risk_service.py
+++ b/backend/app/services/risk_service.py
@@ -1,0 +1,14 @@
+from uuid import UUID
+from typing import List
+from ..models import RiskIndicator
+
+# Temporary in-memory data store
+_fake_indicators: List[RiskIndicator] = []
+
+
+def list_indicators() -> List[RiskIndicator]:
+    return _fake_indicators
+
+
+def add_indicator(indicator: RiskIndicator) -> None:
+    _fake_indicators.append(indicator)

--- a/backend/app/services/risk_service.py
+++ b/backend/app/services/risk_service.py
@@ -1,6 +1,7 @@
 from typing import List
 from ..models import RiskIndicator
 
+
 # Temporary in-memory data store
 _fake_indicators: List[RiskIndicator] = []
 

--- a/backend/app/services/risk_service.py
+++ b/backend/app/services/risk_service.py
@@ -1,4 +1,3 @@
-from uuid import UUID
 from typing import List
 from ..models import RiskIndicator
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
 fastapi
 uvicorn
 pydantic
+httpx
 pytest
 flake8

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,5 @@
 fastapi
 uvicorn
 pydantic
+pytest
+flake8

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,7 @@
 fastapi
 uvicorn
 pydantic
+pydantic-settings
 httpx
 pytest
 flake8

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -3,6 +3,7 @@ from app.main import app
 
 client = TestClient(app)
 
+
 def test_read_root():
     response = client.get("/")
     assert response.status_code == 200

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,6 +1,7 @@
 from fastapi.testclient import TestClient
 from app.main import app
 
+
 client = TestClient(app)
 
 

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_read_root():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "message" in response.json()
+
+
+def test_ws_risk():
+    with client.websocket_connect("/ws/risk") as websocket:
+        data = websocket.receive_text()
+        assert data == "risk_stream_connected"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203


### PR DESCRIPTION
## Summary
- implement Pydantic settings for configuration
- add simple service layer for risk, metrics and alerts
- expose websocket route and return settings info
- introduce enum types for risk level and alert severity
- add pytest-based tests and GitHub Actions workflow
- document running the tests and environment setup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684e65354a8483218020f93c1ad200a2